### PR TITLE
Chore/bump spock and groovy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -313,7 +313,7 @@
                       <dependency>
                           <groupId>org.codehaus.groovy</groupId>
                           <artifactId>groovy-all</artifactId>
-                          <version>2.0.5</version>
+                          <version>2.4.21</version>
                       </dependency>
                   </dependencies>
               </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <parent>
     <groupId>org.jasig.parent</groupId>
@@ -31,7 +32,7 @@
     <commons-lang.version>2.6</commons-lang.version>
     <guava.version>33.3.1-jre</guava.version>
     <!-- Hibernate should match uPortal version for consistency -->
-    <hibernate.version>5.3.20.Final</hibernate.version>  
+    <hibernate.version>5.3.20.Final</hibernate.version>
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.15</httpcore.version>
     <joda-time.version>2.11.2</joda-time.version>
@@ -86,11 +87,11 @@
         <artifactId>commons-lang</artifactId>
         <version>${commons-lang.version}</version>
       </dependency>
-        <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-core</artifactId>
-            <version>${hibernate.version}</version>
-        </dependency>
+      <dependency>
+        <groupId>org.hibernate</groupId>
+        <artifactId>hibernate-core</artifactId>
+        <version>${hibernate.version}</version>
+      </dependency>
       <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
@@ -150,22 +151,22 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-          <version>${spring.version}</version>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-webmvc</artifactId>
-          <version>${spring.version}</version>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-webmvc-portlet</artifactId>
-          <version>${spring.version}</version>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc-portlet</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
-          <groupId>org.springframework</groupId>
-          <artifactId>spring-context</artifactId>
-          <version>${spring.version}</version>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <version>${spring.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
@@ -178,10 +179,10 @@
         <version>${spring-ws.version}</version>
       </dependency>
       <dependency>
-          <groupId>javax.portlet</groupId>
-          <artifactId>portlet-api</artifactId>
-          <version>${portlet-api.version}</version>
-          <scope>provided</scope>
+        <groupId>javax.portlet</groupId>
+        <artifactId>portlet-api</artifactId>
+        <version>${portlet-api.version}</version>
+        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>jakarta.xml.bind</groupId>
@@ -194,136 +195,136 @@
         <version>${jaxb.version}</version>
       </dependency>
 
-        <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
-        <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <!-- End of logging section -->
+      <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.2</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+      </dependency>
+      <!-- End of logging section -->
 
-        <!-- ===== Test Dependencies ================================== -->
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
-            <version>${spock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-bom</artifactId>
-            <version>2.3-groovy-4.0</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-junit4</artifactId>
-            <scope>test</scope>
-        </dependency>
+      <!-- ===== Test Dependencies ================================== -->
+      <dependency>
+        <groupId>org.spockframework</groupId>
+        <artifactId>spock-core</artifactId>
+        <version>${spock.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.spockframework</groupId>
+        <artifactId>spock-bom</artifactId>
+        <version>2.3-groovy-4.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.spockframework</groupId>
+        <artifactId>spock-junit4</artifactId>
+        <scope>test</scope>
+      </dependency>
 
-        <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jul-to-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
-        </dependency>
+      <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>log4j-over-slf4j</artifactId>
+        <version>${slf4j.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${logback.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
   <build>
     <pluginManagement>
-    <plugins>
-      <plugin>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>enforce-versions</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireMavenVersion>
-                  <version>2.2</version>
-                </requireMavenVersion>
-                <requireJavaVersion>
-                  <version>1.6</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
-        <dependencies>
-          <dependency>
-          <groupId>org.apache.maven.scm</groupId>
+      <plugins>
+        <plugin>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>enforce-versions</id>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireMavenVersion>
+                    <version>2.2</version>
+                  </requireMavenVersion>
+                  <requireJavaVersion>
+                    <version>1.6</version>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
               <version>1.13.0</version>
-             </dependency>
-            </dependencies>
-            <configuration>
-                <autoVersionSubmodules>true</autoVersionSubmodules>
-                <localCheckout>true</localCheckout>
-            </configuration>
+            </dependency>
+          </dependencies>
+          <configuration>
+            <autoVersionSubmodules>true</autoVersionSubmodules>
+            <localCheckout>true</localCheckout>
+          </configuration>
         </plugin>
-              <plugin>
-                  <groupId>org.codehaus.gmavenplus</groupId>
-                  <artifactId>gmavenplus-plugin</artifactId>
-                  <version>3.0.2</version>
-                  <executions>
-                      <execution>
-                          <goals>
-                              <goal>compile</goal>
-                              <goal>compileTests</goal>
-                          </goals>
-                      </execution>
-                  </executions>
-              </plugin>
-              <plugin>
-                  <groupId>com.mycila.maven-license-plugin</groupId>
-                  <artifactId>maven-license-plugin</artifactId>
-                  <configuration>
-                      <aggregate>true</aggregate>
-                      <excludes>
-                          <exclude>**/NOTICE</exclude>
-                          <exclude>README</exclude>
-                          <exclude>LICENSE</exclude>
-                          <exclude>**/.gitignore</exclude>
-                          <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
-                          <exclude>**/overlays/**</exclude>  <!-- for intelliJ Idea -->
-                      </excludes>
-                  </configuration>
-              </plugin>
-          </plugins>
-      </pluginManagement>
+        <plugin>
+          <groupId>org.codehaus.gmavenplus</groupId>
+          <artifactId>gmavenplus-plugin</artifactId>
+          <version>3.0.2</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>compile</goal>
+                <goal>compileTests</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>com.mycila.maven-license-plugin</groupId>
+          <artifactId>maven-license-plugin</artifactId>
+          <configuration>
+            <aggregate>true</aggregate>
+            <excludes>
+              <exclude>**/NOTICE</exclude>
+              <exclude>README</exclude>
+              <exclude>LICENSE</exclude>
+              <exclude>**/.gitignore</exclude>
+              <exclude>.idea/**</exclude>  <!-- for intelliJ Idea -->
+              <exclude>**/overlays/**</exclude>  <!-- for intelliJ Idea -->
+            </excludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <spring-security.version>5.7.12</spring-security.version>
     <spring-ws.version>2.4.7.RELEASE</spring-ws.version>
     <spring.version>3.2.18.RELEASE</spring.version>
-    <spock.version>0.7-groovy-2.0</spock.version>
+    <spock.version>2.4-M4-groovy-4.0</spock.version>
     <tomcat-jdbc.version>7.0.109</tomcat-jdbc.version>
 
     <project.build.sourceVersion>1.8</project.build.sourceVersion>
@@ -220,6 +220,18 @@
             <version>${spock.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-bom</artifactId>
+            <version>2.3-groovy-4.0</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-junit4</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- For sl4j/logback logging, see https://wiki.jasig.org/display/PLT/Logging+Best+Practices -->
         <dependency>
@@ -244,6 +256,7 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
     <plugins>
       <plugin>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -281,41 +294,18 @@
                 <localCheckout>true</localCheckout>
             </configuration>
         </plugin>
-   </plugins>
-      <pluginManagement>
-          <plugins>
               <plugin>
-                  <groupId>org.codehaus.gmaven</groupId>
-                  <artifactId>gmaven-plugin</artifactId>
-                  <version>1.5</version>
-                  <configuration>
-                      <providerSelection>1.7</providerSelection>
-                  </configuration>
+                  <groupId>org.codehaus.gmavenplus</groupId>
+                  <artifactId>gmavenplus-plugin</artifactId>
+                  <version>3.0.2</version>
                   <executions>
                       <execution>
                           <goals>
-                              <goal>testCompile</goal>
+                              <goal>compile</goal>
+                              <goal>compileTests</goal>
                           </goals>
                       </execution>
                   </executions>
-                  <dependencies>
-                      <dependency>
-                          <groupId>org.codehaus.gmaven.runtime</groupId>
-                          <artifactId>gmaven-runtime-2.0</artifactId>
-                          <version>1.5</version>
-                          <exclusions>
-                              <exclusion>
-                                  <groupId>org.codehaus.groovy</groupId>
-                                  <artifactId>groovy-all</artifactId>
-                              </exclusion>
-                          </exclusions>
-                      </dependency>
-                      <dependency>
-                          <groupId>org.codehaus.groovy</groupId>
-                          <artifactId>groovy-all</artifactId>
-                          <version>2.4.21</version>
-                      </dependency>
-                  </dependencies>
               </plugin>
               <plugin>
                   <groupId>com.mycila.maven-license-plugin</groupId>


### PR DESCRIPTION
This PR supersedes https://github.com/uPortal-Project/portlet-utils/pull/64

In order to bump groovy, a spock bump was also needed. In order to bump spock, it was necessary to swap out the gmaven-plugin with gmavenplus-plugin.

Note that this PR also includes a formatting commit to set the indents consistently to two spaces as per the apache maven documentation (and a majority of the file itself).